### PR TITLE
#28 仕様変更のため中間テーブルの削除及び Gadgetモデルに外部キーを設置

### DIFF
--- a/app/forms/post_form.rb
+++ b/app/forms/post_form.rb
@@ -23,8 +23,6 @@ class PostForm
     ActiveRecord::Base.transaction do
       post = Post.create!(user_id:, image:)
       gadget = Gadget.create!(name:, brand:, price:, image_url:, genre:)
-
-      PostGadget.create!(post_id: post.id, gadget_id: gadget.id)
     end
   rescue ActiveRecord::RecordInvalid
     false

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -11,7 +11,6 @@ export default class extends Controller {
     const imageUrl = this.imageUrlTarget.value;
     const genre = this.genreTarget.value;
 
-    console.log(genre)
     // 非表示
     document.querySelector('#main_form_name').value = name;
     document.querySelector('#main_form_brand').value = brand;

--- a/app/models/gadget.rb
+++ b/app/models/gadget.rb
@@ -1,6 +1,5 @@
 class Gadget < ApplicationRecord
-  has_many :post_gadgets, dependent: :destroy
-  has_many :posts, through: :post_gadgets
+  belongs_to :post
 
   enum genre: { keyboard: 0, monitor: 1 }
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,6 +1,5 @@
 class Post < ApplicationRecord
-  has_many :post_gadgets, dependent: :destroy
-  has_many :gadgets, through: :post_gadgets
+  has_many :gadgets, dependent: :destroy
   belongs_to :user
 
   mount_uploader :image, PostImageUploader

--- a/app/models/post_gadget.rb
+++ b/app/models/post_gadget.rb
@@ -1,4 +1,0 @@
-class PostGadget < ApplicationRecord
-  belongs_to :post
-  belongs_to :gadget
-end

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -7,11 +7,11 @@
     <%= render 'posts/modal_gadget', form: form %>
 
     <div class="hidden">
+      <%= form.select :genre, Gadget.genres_i18n.invert, {include_blank: '未選択'}, { id: 'main_form_genre', readonly: true } %>
+      <%= form.url_field :image_url, id: 'main_form_imageUrl', class: 'input input-bordered w-full max-w-xs' %>
       <%= form.text_field :name, id: 'main_form_name', class: 'input input-bordered w-full max-w-xs' %>
       <%= form.text_field :brand, id: 'main_form_brand', class: 'input input-bordered w-full max-w-xs' %>
       <%= form.number_field :price, id: 'main_form_price', class: 'input input-bordered w-full max-w-xs' %>
-      <%= form.url_field :image_url, id: 'main_form_imageUrl', class: 'input input-bordered w-full max-w-xs' %>
-      <%= form.select :genre, Gadget.genres_i18n.invert, {include_blank: '未選択'}, { id: 'main_form_genre', readonly: true } %>
     </div>
 
     <div id="subitems" class="hidden border border-gray-200 rounded-lg p-6 shadow">

--- a/db/migrate/20231225125652_drop_post_gadget.rb
+++ b/db/migrate/20231225125652_drop_post_gadget.rb
@@ -1,0 +1,10 @@
+class DropPostGadget < ActiveRecord::Migration[7.0]
+  def change
+    drop_table :post_gadgets do |t|
+      t.references :post, foreign_key: true
+      t.references :gadget, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20231225130013_add_gadget_reference_to_post.rb
+++ b/db/migrate/20231225130013_add_gadget_reference_to_post.rb
@@ -1,0 +1,5 @@
+class AddGadgetReferenceToPost < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :gadgets, :post, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_07_131109) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_25_130013) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -22,15 +22,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_07_131109) do
     t.integer "genre"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-  end
-
-  create_table "post_gadgets", force: :cascade do |t|
     t.bigint "post_id"
-    t.bigint "gadget_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["gadget_id"], name: "index_post_gadgets_on_gadget_id"
-    t.index ["post_id"], name: "index_post_gadgets_on_post_id"
+    t.index ["post_id"], name: "index_gadgets_on_post_id"
   end
 
   create_table "posts", force: :cascade do |t|
@@ -52,7 +45,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_07_131109) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
-  add_foreign_key "post_gadgets", "gadgets"
-  add_foreign_key "post_gadgets", "posts"
+  add_foreign_key "gadgets", "posts"
   add_foreign_key "posts", "users"
 end


### PR DESCRIPTION
PostモデルとGadgetモデルは多対多とする必要がなかったため、
マイグレーションファイルにてPostGadgetモデルを削除し、GadgetモデルにPostモデルの外部キーを設置