### PR TITLE
パスワードリセットの本番環境の設定追加

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,5 +1,4 @@
 class UserMailer < ApplicationMailer
-  default from: 'from@example.com'
   def reset_password_email(user)
     @user = User.find(user.id)
     @url = edit_password_reset_url(@user.reset_password_token)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -74,7 +74,7 @@ Rails.application.configure do
     domain: 'gmail.com',
     user_name: ENV['GMAIL_USERNAME'],
     password: ENV['GMAIL_PASSWORD'],
-    authentication: 'login',
+    authentication: 'plain',
     enable_starttls_auto: true
   }
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -64,7 +64,7 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
-  config.action_mailer.default_url_options = Settings.default_url_options
+  config.action_mailer.default_url_options = Settings.default_url_options.to_h
   config.action_mailer.raise_delivery_errors = true
 
   config.action_mailer.delivery_method = :smtp

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -90,4 +90,6 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  config.action_mailer.default_url_options = { host: 'https://desktech-connect-ba757d0b0928.herokuapp.com' }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -63,13 +63,15 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "myapp_production"
 
   config.action_mailer.perform_caching = false
+
+  config.action_mailer.default_url_options = 'https://desktech-connect-ba757d0b0928.herokuapp.com/'
   config.action_mailer.raise_delivery_errors = true
 
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
     address: 'smtp.gmail.com',
     port: 587,
-    domain: 'desktech-connect-ba757d0b0928.herokuapp.com',
+    domain: 'gmail.com',
     user_name: ENV['GMAIL_USERNAME'],
     password: ENV['GMAIL_PASSWORD'],
     authentication: 'plain',

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -74,7 +74,7 @@ Rails.application.configure do
     domain: 'gmail.com',
     user_name: ENV['GMAIL_USERNAME'],
     password: ENV['GMAIL_PASSWORD'],
-    authentication: 'plain',
+    authentication: 'login',
     enable_starttls_auto: true
   }
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -64,7 +64,7 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
-  config.action_mailer.default_url_options = 'https://desktech-connect-ba757d0b0928.herokuapp.com/'
+  config.action_mailer.default_url_options = Settings.default_url_options
   config.action_mailer.raise_delivery_errors = true
 
   config.action_mailer.delivery_method = :smtp

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -63,10 +63,18 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "myapp_production"
 
   config.action_mailer.perform_caching = false
+  config.action_mailer.raise_delivery_errors = true
 
-  # Ignore bad email addresses and do not raise email delivery errors.
-  # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address: 'smtp.gmail.com',
+    port: 587,
+    domain: 'https://desktech-connect-ba757d0b0928.herokuapp.com',
+    user_name: ENV['GMAIL_USERNAME'],
+    password: ENV['GMAIL_PASSWORD'],
+    authentication: 'plain',
+    enable_starttls_auto: true
+  }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
@@ -91,5 +99,4 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  config.action_mailer.default_url_options = { host: 'https://desktech-connect-ba757d0b0928.herokuapp.com' }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -69,7 +69,7 @@ Rails.application.configure do
   config.action_mailer.smtp_settings = {
     address: 'smtp.gmail.com',
     port: 587,
-    domain: 'https://desktech-connect-ba757d0b0928.herokuapp.com',
+    domain: 'desktech-connect-ba757d0b0928.herokuapp.com',
     user_name: ENV['GMAIL_USERNAME'],
     password: ENV['GMAIL_PASSWORD'],
     authentication: 'plain',

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,2 +1,6 @@
 sorcery:
   callback_url: "https://desktech-connect-ba757d0b0928.herokuapp.com/oauth/callback?provider=twitter"
+
+default_url_options:
+  protocol: 'https'
+  host: 'https://desktech-connect-ba757d0b0928.herokuapp.com'

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -3,4 +3,4 @@ sorcery:
 
 default_url_options:
   protocol: 'https'
-  host: 'https://desktech-connect-ba757d0b0928.herokuapp.com'
+  host: 'desktech-connect-ba757d0b0928.herokuapp.com'


### PR DESCRIPTION
## 内容
パスワードリセットの本番用の設定が抜けていたため、設定を追加
## 変更内容
Gmailアカウントを新規作成し、そのアカウントからリセット用のメールを送信するように設定