### PR TITLE
Add:アップロードされた画像の拡張子をwebpに変換

### DIFF
--- a/app/uploaders/post_image_uploader.rb
+++ b/app/uploaders/post_image_uploader.rb
@@ -41,12 +41,21 @@ class PostImageUploader < CarrierWave::Uploader::Base
   # Add an allowlist of extensions which are allowed to be uploaded.
   # For images you might use something like this:
   def extension_allowlist
-    %w(jpg jpeg png)
+    %w(jpg jpeg png webp)
+  end
+
+  process :convert_to_webp
+
+  def convert_to_webp
+    manipulate! do |img|
+      img.format 'webp'
+      img
+    end
   end
 
   # Override the filename of the uploaded files:
   # Avoid using model.id or version_name here, see uploader/store.rb for details.
-  # def filename
-  #   "something.jpg" if original_filename
-  # end
+  def filename
+    super.chomp(File.extname(super)) + '.webp' if original_filename.present?
+  end
 end


### PR DESCRIPTION
## 変更内容
Carrierwaveを用いてアップロードした画像ファイルの拡張子をwebpに変換するように、post_image_uploader.rbを追加設定を施した。